### PR TITLE
issue#422

### DIFF
--- a/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
+++ b/RoaringBitmap/src/main/java/org/roaringbitmap/longlong/HighLowContainer.java
@@ -111,6 +111,10 @@ public class HighLowContainer {
     }
     art.serializeArt(byteBuffer);
     containers.serialize(byteBuffer);
+    if(byteBuffer != buffer)
+    {
+      buffer.position(buffer.position() + byteBuffer.position());
+    }
   }
 
   /**


### PR DESCRIPTION
Roaring64Bitmap.serialize(ByteBuffer) not populating ByteBuffer position value for BigEndian byteOrder buffers #422